### PR TITLE
Merge upstream bugfix: Don't represent SRDelegateAvailableMethods as a bitfield

### DIFF
--- a/SocketRocket/Internal/Delegate/SRDelegateController.h
+++ b/SocketRocket/Internal/Delegate/SRDelegateController.h
@@ -14,15 +14,15 @@
 NS_ASSUME_NONNULL_BEGIN
 
 struct SRDelegateAvailableMethods {
-    BOOL didReceiveMessage : 1;
-    BOOL didReceiveMessageWithString : 1;
-    BOOL didReceiveMessageWithData : 1;
-    BOOL didOpen : 1;
-    BOOL didFailWithError : 1;
-    BOOL didCloseWithCode : 1;
-    BOOL didReceivePing : 1;
-    BOOL didReceivePong : 1;
-    BOOL shouldConvertTextFrameToString : 1;
+    BOOL didReceiveMessage;
+    BOOL didReceiveMessageWithString;
+    BOOL didReceiveMessageWithData;
+    BOOL didOpen;
+    BOOL didFailWithError;
+    BOOL didCloseWithCode;
+    BOOL didReceivePing;
+    BOOL didReceivePong;
+    BOOL shouldConvertTextFrameToString;
 };
 typedef struct SRDelegateAvailableMethods SRDelegateAvailableMethods;
 


### PR DESCRIPTION
Since Objective-C uses a signed char for BOOL on some platforms (macOS and 32-bit iOS) packing this into a bitfield doesn't work since when it tries to read the field it looks for the sign bit and fails with an EXC_BAD_INSTRUCTION. This change sacrifices a few bits for the extra portability.